### PR TITLE
뷰 추가

### DIFF
--- a/mysite/polls/urls.py
+++ b/mysite/polls/urls.py
@@ -2,5 +2,8 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.index, name='index')
+    path('', views.index, name='index'),
+    path('<int:question_id>/', views.detail, name='detail'),
+    path('<int:question_id>/results/', views.results, name='results'),
+    path('<int:question_id>/vote/', views.vote, name='vote'),
 ]

--- a/mysite/polls/views.py
+++ b/mysite/polls/views.py
@@ -5,3 +5,13 @@ from django.shortcuts import render
 
 def index(request):
     return HttpResponse("Hello, world. You're at the polls inex")
+
+def detail(request, question_id):
+    return HttpResponse("You're looking at question %s." % question_id)
+
+def results(request, question_id):
+    response = "You're looking at the results of question %s."
+    return HttpResponse(response % question_id)
+
+def vote(request, question_id):
+    return HttpResponse("You're voting on question %s" % question_id)


### PR DESCRIPTION
- **polls/views.py** 에 뷰를 추가
- **path()** 호출을 추가하여 새로운 뷰를 **polls.urls** 모듈로 연결
- 사용자가 웹사이트의 페이지를 요청할 때, 예로 “/polls/34/”를 요청했다고 하면, Django는 **mysite.urls** 파이썬 모듈을 불러오게 됩니다. **ROOT_URLCONF** 설정에 의해 해당 모듈을 바라보도록 지정되어 있기 때문입니다. **mysite.urls**에서 **urlpatterns**라는 변수를 찾고, 순서대로 패턴을 따라갑니다. '**polls/**'를 찾은 후엔, 일치하는 텍스트("**polls/**")를 버리고, 남은 텍스트인 "**34/**"를 ‘polls.urls’ URLconf로 전달하여 남은 처리를 진행합니다. 거기에 '**<int:question_id>/**'와 일치하여, 결과적으로 **detail()** 뷰 함수가 호출됩니다.