### PR TITLE
Spare

### DIFF
--- a/mysite/polls/templates/polls/detail.html
+++ b/mysite/polls/templates/polls/detail.html
@@ -1,0 +1,1 @@
+{{ question }}

--- a/mysite/polls/templates/polls/index.html
+++ b/mysite/polls/templates/polls/index.html
@@ -1,0 +1,9 @@
+{% if latest_question_list %}
+    <ul>
+    {% for question in latest_question_list %}
+        <li><a href="/polls/{{ question.id }}/">{{ question.question_text }}</a></li>
+    {% endfor %}
+    </ul>
+{% else %}
+    <p>No polls are available.</p>
+{% endif %}

--- a/mysite/polls/views.py
+++ b/mysite/polls/views.py
@@ -1,5 +1,5 @@
-from django.http import HttpResponse
-from django.shortcuts import render
+from django.http import Http404, HttpResponse
+from django.shortcuts import get_object_or_404 ,render
 from django.template import loader
 
 from .models import Question
@@ -18,7 +18,13 @@ def index(request):
     return render(request, 'polls/index.html', context)
 
 def detail(request, question_id):
-    return HttpResponse("You're looking at question %s." % question_id)
+    # try:
+    #     question = Question.objects.get(pk=question_id)
+    # except Question.DoesNotExist:
+    #     raise Http404("Question does not exist")
+    question = get_object_or_404(Question, pk=question_id)
+    return render(request, 'polls/detail.html', {'question': question})
+    # return HttpResponse("You're looking at question %s." % question_id)
 
 def results(request, question_id):
     response = "You're looking at the results of question %s."
@@ -26,5 +32,3 @@ def results(request, question_id):
 
 def vote(request, question_id):
     return HttpResponse("You're voting on question %s" % question_id)
-
-# def index(request):

--- a/mysite/polls/views.py
+++ b/mysite/polls/views.py
@@ -1,10 +1,21 @@
 from django.http import HttpResponse
 from django.shortcuts import render
+from django.template import loader
+
+from .models import Question
 
 # Create your views here.
 
 def index(request):
-    return HttpResponse("Hello, world. You're at the polls inex")
+    # latest_question_list = Question.objects.order_by('-pub_date')[:5]
+    # output = ', '.join([q.question_text for q in latest_question_list])
+    # return HttpResponse(output)
+    latest_question_list = Question.objects.order_by('-pub_date')[:5]
+    # template = loader.get_template('polls/index.html')
+    context = {
+        'latest_question_list': latest_question_list,
+    }
+    return render(request, 'polls/index.html', context)
 
 def detail(request, question_id):
     return HttpResponse("You're looking at question %s." % question_id)
@@ -15,3 +26,5 @@ def results(request, question_id):
 
 def vote(request, question_id):
     return HttpResponse("You're voting on question %s" % question_id)
+
+# def index(request):


### PR DESCRIPTION
**뷰가 실제로 뭔가를 하도록 만들기**
- 뷰에서 페이지의 디자인이 하드코딩 되어 있다고 합시다. 만약 페이지가 보여지는 방식을 바꾸고 싶다면, 이 Python 코드를 편집해야만 할 겁니다. 그럼, 뷰에서 사용할 수 있는 템플릿을 작성하여, Python 코드로부터 디자인을 분리하도록 Django의 템플릿 시스템을 사용해 봅시다.
- 우선, **polls** 디렉토리에 **templates**라는 디렉토리를 만듭니다. Django는 여기서 템플릿을 찾게 될 것입니다.
- 방금 만든 **templates** 디렉터리 내에 **polls** 라는 다른 디렉터리를 만들고 그 안에 **index.html** 이라는 파일을 만듭니다. 즉, 템플릿은 **polls/templates/polls/index.html**이어야 합니다. 위에서 설명한 것처럼 **app_directories** 템플릿 로더가 작동하는 방식 때문에 Django 내에 있는 이 템플릿을 polls/index.html로 지칭할 수 있습니다.

**404 에러 일으키기**
- 뷰는 요청된 질문의 ID 가 없을 경우 [Http404](https://docs.djangoproject.com/ko/4.0/topics/http/views/#django.http.Http404) 예외를 발생시킵니다.
- 만약 객체가 존재하지 않을 때 [get()](https://docs.djangoproject.com/ko/4.0/ref/models/querysets/#django.db.models.query.QuerySet.get) 을 사용하여 [Http404](https://docs.djangoproject.com/ko/4.0/topics/http/views/#django.http.Http404) 예외를 발생시키는것은 자주 쓰이는 용법입니다.