### PR TITLE
URL의 이름공간 정하기

### DIFF
--- a/mysite/polls/templates/polls/index.html
+++ b/mysite/polls/templates/polls/index.html
@@ -2,7 +2,7 @@
     <ul>
     {% for question in latest_question_list %}
         {% comment %} <li><a href="/polls/{{ question.id }}/">{{ question.question_text }}</a></li> {% endcomment %}
-        <li><a href="{% url 'detail' question.id %}">{{ question.question_text }}</a></li>
+        <li><a href="{% url 'polls:detail' question.id %}">{{ question.question_text }}</a></li>
     {% endfor %}
     </ul>
 {% else %}

--- a/mysite/polls/urls.py
+++ b/mysite/polls/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 from . import views
 
+app_name = 'polls'
 urlpatterns = [
     path('', views.index, name='index'),
     path('specifics/<int:question_id>/', views.detail, name='detail'),


### PR DESCRIPTION
- 튜토리얼의 프로젝트는 **polls**라는 앱 하나만 가지고 진행했습니다. 실제 Django 프로젝트는 앱이 몇개라도 올 수 있습니다. Django는 이 앱들의 URL을 어떻게 구별해 낼까요? 예를 들어, **polls** 앱은 **detail**이라는 뷰를 가지고 있고, 동일한 프로젝트에 블로그를 위한 앱이 있을 수도 있습니다. Django가 **{% url %}** 템플릿태그를 사용할 때, 어떤 앱의 뷰에서 URL을 생성할지 알 수 있을까요?

- 정답은 URLconf에 이름공간(namespace)을 추가하는 것입니다. **polls/urls.py** 파일에 **app_name**을 추가하여 어플리케이션의 이름공간을 설정할 수 있습니다.